### PR TITLE
fix: mode in swanlab_utils file

### DIFF
--- a/src/lerobot/utils/swanlab_utils.py
+++ b/src/lerobot/utils/swanlab_utils.py
@@ -83,7 +83,7 @@ class SwanLabLogger:
             config=cfg.to_dict(),
             save_code=False,
             resume=cfg.resume,
-            mode=self.cfg.mode if self.cfg.mode in ["online", "offline", "disabled"] else "online",
+            mode=self.cfg.mode if self.cfg.mode in ["cloud", "offline", "local", "disabled"] else "cloud",
         )
         run_id = self._run.public.run_id
         # NOTE: We will override the cfg.swanlab.run_id with the swanlab run id.


### PR DESCRIPTION
Options are `cloud`, `offline`, `local`, `disabled`, and view the [swanlab document](https://docs.swanlab.cn/en/api/py-init.html).

